### PR TITLE
Add Streamlit investment insights app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AI Investment Insights App
+
+This repository contains a simple Streamlit application for analyzing investment data for up to three companies. Users can upload JSON files containing stock price data, news articles, and SEC filings. The app applies basic quantitative finance and NLP techniques to generate insights and visualizations.
+
+## Running the App
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   python -m textblob.download_corpora
+   python -m spacy download en_core_web_sm
+   ```
+
+2. Launch Streamlit:
+   ```bash
+   streamlit run app.py
+   ```
+
+## Features
+- Upload and assign JSON files to companies
+- Stock price indicators (moving averages, Bollinger Bands, RSI)
+- News and filing sentiment analysis with keyword frequency
+- Cross-company comparison charts and downloadable CSV summaries

--- a/app.py
+++ b/app.py
@@ -1,0 +1,73 @@
+import io
+from typing import Dict
+
+import altair as alt
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from utils import (
+    aggregate_sentiment,
+    analyze_text_df,
+    company_summary,
+    compute_stock_indicators,
+    parse_uploaded_files,
+)
+
+st.set_page_config(page_title="Investment Insights", layout="wide")
+
+st.title("Multi-Company Investment Insight App")
+
+uploaded = st.file_uploader(
+    "Upload JSON files (max 3 companies)",
+    accept_multiple_files=True,
+    type="json",
+)
+
+if uploaded:
+    companies = parse_uploaded_files(uploaded)
+
+    summaries = []
+    tabs = st.tabs(list(companies.keys()))
+    for (company, data), tab in zip(companies.items(), tabs):
+        with tab:
+            st.header(company)
+            if "stock" in data:
+                data["stock"] = compute_stock_indicators(data["stock"])
+                fig = px.line(
+                    data["stock"],
+                    x="date",
+                    y=["close", "ma20", "ma50", "ma200"],
+                    title=f"{company} Price & MAs",
+                )
+                st.plotly_chart(fig, use_container_width=True)
+                rsi_chart = alt.Chart(data["stock"]).mark_line().encode(
+                    x="date:T", y="rsi:Q"
+                ).properties(title="RSI")
+                st.altair_chart(rsi_chart, use_container_width=True)
+                csv = data["stock"].to_csv(index=False).encode("utf-8")
+                st.download_button(
+                    "Download Stock Data", data=csv, file_name=f"{company}_stock.csv"
+                )
+            if "news" in data:
+                data["news"] = analyze_text_df(data["news"])
+                trend = aggregate_sentiment(data["news"])
+                fig = px.line(trend, x="date", y="sentiment", title="News Sentiment")
+                st.plotly_chart(fig, use_container_width=True)
+            if "filings" in data:
+                data["filings"] = analyze_text_df(data["filings"])
+                word_freq = pd.DataFrame(data["filings"]["keywords"].tolist()).sum()
+                word_chart = alt.Chart(
+                    word_freq.reset_index().rename({"index": "keyword", 0: "count"}, axis=1)
+                ).mark_bar().encode(x="keyword", y="count")
+                st.altair_chart(word_chart, use_container_width=True)
+            summaries.append(company_summary(company, data))
+
+    if summaries:
+        summary_df = pd.concat(summaries, ignore_index=True)
+        st.subheader("Company Comparison")
+        st.dataframe(summary_df)
+        csv = summary_df.to_csv(index=False).encode("utf-8")
+        st.download_button("Download Summary", data=csv, file_name="summary.csv")
+else:
+    st.info("Upload company JSON files to begin.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+streamlit
+pandas
+numpy
+plotly
+altair
+scikit-learn
+textblob
+spacy
+wordcloud

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,116 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+from textblob import TextBlob
+import spacy
+
+nlp = None
+try:
+    nlp = spacy.load("en_core_web_sm")
+except Exception:
+    nlp = None
+
+KEYWORDS = ["AI", "M&A", "earnings", "guidance"]
+
+
+def load_json(file) -> List[dict]:
+    """Load JSON content from uploaded file."""
+    if hasattr(file, "read"):
+        data = json.load(file)
+    else:
+        with open(file) as f:
+            data = json.load(f)
+    return data
+
+
+def parse_uploaded_files(uploaded_files: List) -> Dict[str, Dict[str, pd.DataFrame]]:
+    """Parse uploaded JSON files and organize them by company and type."""
+    companies: Dict[str, Dict[str, pd.DataFrame]] = {}
+    for upl in uploaded_files:
+        name = Path(upl.name).stem
+        parts = name.split("_")
+        company = parts[0]
+        ftype = "unknown"
+        if "stock" in name.lower():
+            ftype = "stock"
+        elif "news" in name.lower():
+            ftype = "news"
+        elif "filing" in name.lower() or "sec" in name.lower():
+            ftype = "filings"
+        data = load_json(upl)
+        df = pd.DataFrame(data)
+        if company not in companies:
+            companies[company] = {}
+        companies[company][ftype] = df
+    return companies
+
+
+def compute_stock_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Add moving averages, Bollinger Bands, and RSI to stock dataframe."""
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df.sort_values("date", inplace=True)
+    df["return"] = df["close"].pct_change()
+    for window in [20, 50, 200]:
+        df[f"ma{window}"] = df["close"].rolling(window).mean()
+    # Bollinger Bands
+    df["std20"] = df["close"].rolling(20).std()
+    df["bb_upper"] = df["ma20"] + 2 * df["std20"]
+    df["bb_lower"] = df["ma20"] - 2 * df["std20"]
+    # RSI
+    delta = df["close"].diff()
+    gain = (delta.where(delta > 0, 0)).rolling(14).mean()
+    loss = (-delta.where(delta < 0, 0)).rolling(14).mean()
+    rs = gain / loss
+    df["rsi"] = 100 - (100 / (1 + rs))
+    return df
+
+
+def analyze_sentiment(text: str) -> float:
+    """Return sentiment polarity using TextBlob."""
+    return TextBlob(text).sentiment.polarity
+
+
+def keyword_frequency(text: str, keywords=KEYWORDS) -> Dict[str, int]:
+    text_lower = text.lower()
+    return {k: text_lower.count(k.lower()) for k in keywords}
+
+
+def extract_entities(text: str) -> List[str]:
+    if not nlp:
+        return []
+    doc = nlp(text)
+    return [ent.text for ent in doc.ents]
+
+
+def analyze_text_df(df: pd.DataFrame, text_col: str = "text") -> pd.DataFrame:
+    df = df.copy()
+    df["sentiment"] = df[text_col].apply(analyze_sentiment)
+    df["keywords"] = df[text_col].apply(keyword_frequency)
+    df["entities"] = df[text_col].apply(extract_entities)
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+def aggregate_sentiment(df: pd.DataFrame) -> pd.DataFrame:
+    if "date" in df.columns:
+        return df.groupby(pd.Grouper(key="date", freq="D"))["sentiment"].mean().reset_index()
+    else:
+        return pd.DataFrame()
+
+
+def company_summary(company: str, data: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    """Return summary metrics for a company."""
+    result = {"company": company}
+    if "stock" in data:
+        result["return_%"] = data["stock"]["return"].sum() * 100
+        result["volatility"] = data["stock"]["return"].std() * np.sqrt(252)
+    if "news" in data:
+        result["avg_news_sentiment"] = data["news"]["sentiment"].mean()
+    if "filings" in data:
+        result["avg_filing_sentiment"] = data["filings"]["sentiment"].mean()
+    return pd.DataFrame([result])


### PR DESCRIPTION
## Summary
- create Streamlit app for analyzing up to three companies
- add finance and NLP utils
- document setup and usage
- provide dependency list

## Testing
- `python -m py_compile app.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686a543e118483298f139cad846ec453