### PR TITLE
Fix scalar JSON parsing error

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -41,6 +41,11 @@ def parse_uploaded_files(uploaded_files: List) -> Dict[str, Dict[str, pd.DataFra
         elif "filing" in name.lower() or "sec" in name.lower():
             ftype = "filings"
         data = load_json(upl)
+        # Convert JSON to DataFrame. If the JSON file represents a single
+        # record (i.e. a dictionary of scalar values), wrap it in a list so
+        # pandas does not raise a ValueError about missing index.
+        if isinstance(data, dict) and not any(isinstance(v, (list, tuple, dict)) for v in data.values()):
+            data = [data]
         df = pd.DataFrame(data)
         if company not in companies:
             companies[company] = {}


### PR DESCRIPTION
## Summary
- handle single-record JSON files in `parse_uploaded_files`

## Testing
- `python -m py_compile app.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686a59711c30832995e034bd5fa13875