### PR TITLE
Fix date parsing in stock indicator computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ This repository contains a simple Streamlit application for analyzing investment
 - Stock price indicators (moving averages, Bollinger Bands, RSI)
 - News and filing sentiment analysis with keyword frequency
 - Cross-company comparison charts and downloadable CSV summaries
+
+## Data Format Notes
+Stock JSON files should include a column representing the trade date. The app
+looks for a column named `date` but will also accept common alternatives such as
+`datetime` or `timestamp`.

--- a/utils.py
+++ b/utils.py
@@ -56,7 +56,16 @@ def parse_uploaded_files(uploaded_files: List) -> Dict[str, Dict[str, pd.DataFra
 def compute_stock_indicators(df: pd.DataFrame) -> pd.DataFrame:
     """Add moving averages, Bollinger Bands, and RSI to stock dataframe."""
     df = df.copy()
-    df["date"] = pd.to_datetime(df["date"])
+    # Normalize potential date column names
+    date_col = None
+    for c in df.columns:
+        if c.lower() in {"date", "datetime", "timestamp", "time"}:
+            date_col = c
+            break
+    if not date_col:
+        raise KeyError("date")
+
+    df["date"] = pd.to_datetime(df[date_col])
     df.sort_values("date", inplace=True)
     df["return"] = df["close"].pct_change()
     for window in [20, 50, 200]:


### PR DESCRIPTION
## Summary
- handle alternative date columns (`datetime`, `timestamp`, `time`) when computing stock indicators
- document date column expectation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5a856e408329b914d75a032a81a8