### PR TITLE
Fix missing news date detection

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -149,8 +149,18 @@ def analyze_text_df(df: pd.DataFrame, text_col: str = "text") -> pd.DataFrame:
     df["sentiment"] = df[text_col].astype(str).apply(analyze_sentiment)
     df["keywords"] = df[text_col].astype(str).apply(keyword_frequency)
     df["entities"] = df[text_col].astype(str).apply(extract_entities)
+    # Normalize potential date column names
+    date_col = None
     if "date" in df.columns:
-        df["date"] = pd.to_datetime(df["date"])
+        date_col = "date"
+    else:
+        for c in df.columns:
+            if c.lower() in {"datetime", "timestamp", "time", "published", "published_at"}:
+                date_col = c
+                break
+
+    if date_col:
+        df["date"] = pd.to_datetime(df[date_col], errors="coerce")
     return df
 
 


### PR DESCRIPTION
## Summary
- find date columns in news datasets using common names like `timestamp` or `published`

## Testing
- `python -m py_compile utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686a65e711a083299aa67efa3dbd5c18