### PR TITLE
Add instructions for scraping data before using uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ This repository contains a simple Streamlit application for analyzing investment
    python -m spacy download en_core_web_sm
    ```
 
-2. Launch Streamlit:
+2. Generate JSON files using the scraping script:
+   ```bash
+   python scrape_data.py TICKER --days 60
+   ```
+
+3. Launch Streamlit:
    ```bash
    streamlit run app.py
    ```

--- a/app.py
+++ b/app.py
@@ -73,4 +73,7 @@ if uploaded:
         csv = summary_df.to_csv(index=False).encode("utf-8")
         st.download_button("Download Summary", data=csv, file_name="summary.csv")
 else:
-    st.info("Upload company JSON files to begin.")
+    st.info(
+        "Step 1: generate JSON files with `scrape_data.py`.\n"
+        "Step 2: upload the generated files here to begin."
+    )


### PR DESCRIPTION
## Summary
- explain scraping step in README before running the app
- notify users in the Streamlit UI that data should be scraped first

## Testing
- `python -m py_compile app.py scrape_data.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686a6aecaa448329b2727cfb033e1bac