### PR TITLE
Fix JSON dump error in stock scraper

### DIFF
--- a/scrape_data.py
+++ b/scrape_data.py
@@ -66,7 +66,15 @@ def save_json(data, filename):
 def fetch_stock_data(ticker: str, days: int):
     end_date = datetime.today()
     start_date = end_date - timedelta(days=days)
-    df = yf.download(ticker, start=start_date.strftime("%Y-%m-%d"), end=end_date.strftime("%Y-%m-%d"), auto_adjust=True)
+    df = yf.download(
+        ticker,
+        start=start_date.strftime("%Y-%m-%d"),
+        end=end_date.strftime("%Y-%m-%d"),
+        auto_adjust=True,
+        progress=False,
+        threads=False,
+        multi_level_index=False,
+    )
     if df.empty:
         raise ValueError("No stock data returned")
     df = df.reset_index()


### PR DESCRIPTION
## Summary
- ensure yfinance returns a flat DataFrame

## Testing
- `python -m py_compile scrape_data.py utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7150c93483298a3374d3d1ed74e1