### PR TITLE
Add Streamlit download buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains a simple Streamlit application for analyzing investment
    python -m spacy download en_core_web_sm
    ```
 
-2. Generate JSON files using the scraping script:
+2. Generate JSON files using the scraping script (or scrape directly in the app):
    ```bash
    python scrape_data.py TICKER --days 60
    ```
@@ -26,5 +26,6 @@ This repository contains a simple Streamlit application for analyzing investment
 - Stock price indicators (moving averages, Bollinger Bands, RSI)
 - News and filing sentiment analysis with keyword frequency
 - Cross-company comparison charts and downloadable CSV summaries
+- Scrape data directly in the app with download buttons
 
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import io
+import json
 from typing import Dict
 
 import altair as alt
@@ -43,8 +44,27 @@ if scrape_button:
         for tkr in tickers:
             with st.spinner(f"Scraping data for {tkr}..."):
                 try:
-                    scrape_main(tkr, int(days_input))
-                    st.success(f"Scraped data for {tkr}. Files saved to current directory.")
+                    result = scrape_main(tkr, int(days_input))
+                    st.success(f"Scraped data for {tkr}. Download files below.")
+                    stock_data = json.dumps(result["stock"], indent=4).encode("utf-8")
+                    st.download_button(
+                        f"Download Stock Data ({tkr})",
+                        stock_data,
+                        file_name=f"{tkr}_stock.json",
+                    )
+                    if result.get("filings"):
+                        filing_data = json.dumps(result["filings"], indent=4).encode("utf-8")
+                        st.download_button(
+                            f"Download Filing ({tkr})",
+                            filing_data,
+                            file_name=f"{tkr}_filing_latest.json",
+                        )
+                    news_data = json.dumps(result["news"], indent=4).encode("utf-8")
+                    st.download_button(
+                        f"Download News ({tkr})",
+                        news_data,
+                        file_name=f"{tkr}_news_{result['timestamp']}.json",
+                    )
                 except Exception as e:  # pragma: no cover - manual operation
                     st.error(f"Failed to scrape data for {tkr}: {e}")
 


### PR DESCRIPTION
## Summary
- return scraped results from `scrape_data.main`
- allow downloading stock, filing and news JSON from the app
- document that scraping can be done in-app with download buttons

## Testing
- `python -m py_compile app.py scrape_data.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a75bc0980832996ba1a3122a7a7fc