### PR TITLE
Combine scraped data downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import io
 import json
+import zipfile
 from typing import Dict
 
 import altair as alt
@@ -23,13 +24,20 @@ st.title("Multi-Company Investment Insight App")
 # ---------- Data Extraction Section ----------
 st.subheader("Data Extraction")
 with st.form("scrape_form"):
-    company_options = {f"{name} ({ticker})": ticker for ticker, name in SEMICONDUCTOR_COMPANIES.items()}
+    company_options = {
+        f"{name} ({ticker})": ticker for ticker, name in SEMICONDUCTOR_COMPANIES.items()
+    }
     tickers_input = st.multiselect(
-        "Select Company", list(company_options.keys()), help="Up to 3 companies", max_selections=3
+        "Select Company",
+        list(company_options.keys()),
+        help="Up to 3 companies",
+        max_selections=3,
     )
 
     day_map = {"30D": 30, "60D": 60, "90D": 90, "120D": 120}
-    days_label = st.selectbox("Days of historical prices", list(day_map.keys()), index=2)
+    days_label = st.selectbox(
+        "Days of historical prices", list(day_map.keys()), index=2
+    )
 
     scrape_button = st.form_submit_button("Start")
 
@@ -45,25 +53,24 @@ if scrape_button:
             with st.spinner(f"Scraping data for {tkr}..."):
                 try:
                     result = scrape_main(tkr, int(days_input))
-                    st.success(f"Scraped data for {tkr}. Download files below.")
+                    st.success(f"Scraped data for {tkr}. Download file below.")
                     stock_data = json.dumps(result["stock"], indent=4).encode("utf-8")
-                    st.download_button(
-                        f"Download Stock Data ({tkr})",
-                        stock_data,
-                        file_name=f"{tkr}_stock.json",
-                    )
-                    if result.get("filings"):
-                        filing_data = json.dumps(result["filings"], indent=4).encode("utf-8")
-                        st.download_button(
-                            f"Download Filing ({tkr})",
-                            filing_data,
-                            file_name=f"{tkr}_filing_latest.json",
-                        )
                     news_data = json.dumps(result["news"], indent=4).encode("utf-8")
+                    zip_buffer = io.BytesIO()
+                    with zipfile.ZipFile(zip_buffer, "w") as zf:
+                        zf.writestr(f"{tkr}_stock.json", stock_data)
+                        if result.get("filings"):
+                            filing_data = json.dumps(
+                                result["filings"], indent=4
+                            ).encode("utf-8")
+                            zf.writestr(f"{tkr}_filing_latest.json", filing_data)
+                        zf.writestr(f"{tkr}_news_{result['timestamp']}.json", news_data)
+                    zip_buffer.seek(0)
                     st.download_button(
-                        f"Download News ({tkr})",
-                        news_data,
-                        file_name=f"{tkr}_news_{result['timestamp']}.json",
+                        f"Download {tkr} Data (zip)",
+                        zip_buffer,
+                        file_name=f"{tkr}_data_{result['timestamp']}.zip",
+                        mime="application/zip",
                     )
                 except Exception as e:  # pragma: no cover - manual operation
                     st.error(f"Failed to scrape data for {tkr}: {e}")
@@ -91,9 +98,12 @@ if uploaded:
                     title=f"{company} Price & MAs",
                 )
                 st.plotly_chart(fig, use_container_width=True)
-                rsi_chart = alt.Chart(data["stock"]).mark_line().encode(
-                    x="date:T", y="rsi:Q"
-                ).properties(title="RSI")
+                rsi_chart = (
+                    alt.Chart(data["stock"])
+                    .mark_line()
+                    .encode(x="date:T", y="rsi:Q")
+                    .properties(title="RSI")
+                )
                 st.altair_chart(rsi_chart, use_container_width=True)
                 csv = data["stock"].to_csv(index=False).encode("utf-8")
                 st.download_button(
@@ -103,16 +113,24 @@ if uploaded:
                 data["news"] = analyze_text_df(data["news"])
                 trend = aggregate_sentiment(data["news"])
                 if not trend.empty and "date" in trend.columns:
-                    fig = px.line(trend, x="date", y="sentiment", title="News Sentiment")
+                    fig = px.line(
+                        trend, x="date", y="sentiment", title="News Sentiment"
+                    )
                     st.plotly_chart(fig, use_container_width=True)
                 else:
                     st.write("News sentiment trend unavailable: no dates provided.")
             if "filings" in data:
                 data["filings"] = analyze_text_df(data["filings"])
                 word_freq = pd.DataFrame(data["filings"]["keywords"].tolist()).sum()
-                word_chart = alt.Chart(
-                    word_freq.reset_index().rename({"index": "keyword", 0: "count"}, axis=1)
-                ).mark_bar().encode(x="keyword", y="count")
+                word_chart = (
+                    alt.Chart(
+                        word_freq.reset_index().rename(
+                            {"index": "keyword", 0: "count"}, axis=1
+                        )
+                    )
+                    .mark_bar()
+                    .encode(x="keyword", y="count")
+                )
                 st.altair_chart(word_chart, use_container_width=True)
             summaries.append(company_summary(company, data))
 


### PR DESCRIPTION
## Summary
- compress scraped JSON files into a single zip
- update UI to offer one download button per ticker

## Testing
- `python -m py_compile app.py scrape_data.py utils.py`
- `black --check app.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7b82dab08329ad5369d54ec8ab67