### PR TITLE
Restrict scraping to single company

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Investment Insights App
 
-This repository contains a simple Streamlit application for analyzing investment data for up to three companies. Users can upload JSON files containing stock price data, news articles, and SEC filings. The app applies basic quantitative finance and NLP techniques to generate insights and visualizations.
+This repository contains a simple Streamlit application for analyzing investment data for a single company at a time. Users can upload JSON files containing stock price data, news articles, and SEC filings. The app applies basic quantitative finance and NLP techniques to generate insights and visualizations.
 
 ## Running the App
 


### PR DESCRIPTION
## Summary
- limit scraping form to a single company selection
- tweak download section text
- clarify README about single-company analysis

## Testing
- `python -m py_compile app.py utils.py scrape_data.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7d4ded748329be4a5f1c34654f7b