### PR TITLE
Add word cloud and cross-company news sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This repository contains a simple Streamlit application for analyzing investment
 ## Features
 - Upload and assign JSON files to companies
 - Stock price indicators (moving averages, Bollinger Bands, RSI)
-- News and filing sentiment analysis with keyword frequency
-- Cross-company comparison charts and downloadable CSV summaries
+- News and filing sentiment analysis with keyword cloud visualization
+- Cross-company news sentiment comparison charts and downloadable CSV summaries
 - Scrape data directly in the app with download buttons
 
 


### PR DESCRIPTION
## Summary
- visualize filing keywords with a word cloud
- track news sentiment for each company and display combined comparison
- update README to mention the new features

## Testing
- `python -m py_compile app.py utils.py scrape_data.py`

------
https://chatgpt.com/codex/tasks/task_e_686a815f67948329a4e0c3438d030bce