### PR TITLE
Fix word cloud crash on empty keyword data

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,10 +120,18 @@ if uploaded:
                     st.write("News sentiment trend unavailable: no dates provided.")
             if "filings" in data:
                 data["filings"] = analyze_text_df(data["filings"])
-                word_freq = pd.DataFrame(data["filings"]["keywords"].tolist()).sum()
-                wc = WordCloud(width=800, height=400, background_color="white")
-                wc = wc.generate_from_frequencies(word_freq.to_dict())
-                st.image(wc.to_array(), use_container_width=True)
+                word_freq = (
+                    pd.DataFrame(data["filings"]["keywords"].tolist())
+                    .sum()
+                    .astype(int)
+                )
+                word_freq = word_freq[word_freq > 0]
+                if not word_freq.empty:
+                    wc = WordCloud(width=800, height=400, background_color="white")
+                    wc = wc.generate_from_frequencies(word_freq.to_dict())
+                    st.image(wc.to_array(), use_container_width=True)
+                else:
+                    st.write("No keyword frequencies found in filings.")
             summaries.append(company_summary(company, data))
 
     if len(sentiment_trends) > 1:


### PR DESCRIPTION
## Summary
- avoid zero division when no keywords are found in filings

## Testing
- `python -m py_compile app.py utils.py scrape_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a83d608708329bfe8e58fac7968d4