### PR TITLE
Implement news sentiment tag cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains a simple Streamlit application for analyzing investment
 - Upload and assign JSON files to companies
 - Stock price indicators (moving averages, Bollinger Bands, RSI)
 - News and filing sentiment analysis with keyword cloud visualization
+- Tag cloud generation from article URLs via `news_analyze`
 - Cross-company news sentiment comparison charts and downloadable CSV summaries
 - Scrape data directly in the app with download buttons
 


### PR DESCRIPTION
## Summary
- show a news sentiment tag cloud in the Streamlit app
- parse lists of news URLs and compute keyword densities via `news_analyze`
- document the new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a8f9303088329a5c6b0b8d9f8788f