### PR TITLE
Add MSI forecasting demo and remove keyword frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,19 @@ This repository contains a simple Streamlit application for analyzing investment
 ## Features
 - Upload and assign JSON files to companies
 - Stock price indicators (moving averages, Bollinger Bands, RSI)
-- News and filing sentiment analysis with keyword cloud visualization
+- News and filing sentiment analysis
 - Tag cloud generation from article URLs via `news_analyze`
 - Cross-company news sentiment comparison charts and downloadable CSV summaries
 - Scrape data directly in the app with download buttons
+
+## MSI Trend Forecasting
+The `msi_forecast.py` script demonstrates monthly silicon wafer shipment (MSI)
+forecasting using SARIMAX and Purchasing Managers' Index (PMI) regression.
+
+Run the script:
+
+```bash
+python msi_forecast.py
+```
 
 

--- a/app.py
+++ b/app.py
@@ -144,18 +144,6 @@ if uploaded:
                     st.image(wc.to_array(), use_container_width=True)
             if "filings" in data:
                 data["filings"] = analyze_text_df(data["filings"])
-                word_freq = (
-                    pd.DataFrame(data["filings"]["keywords"].tolist())
-                    .sum()
-                    .astype(int)
-                )
-                word_freq = word_freq[word_freq > 0]
-                if not word_freq.empty:
-                    wc = WordCloud(width=800, height=400, background_color="white")
-                    wc = wc.generate_from_frequencies(word_freq.to_dict())
-                    st.image(wc.to_array(), use_container_width=True)
-                else:
-                    st.write("No keyword frequencies found in filings.")
             summaries.append(company_summary(company, data))
 
     if len(sentiment_trends) > 1:

--- a/msi_forecast.py
+++ b/msi_forecast.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+
+def generate_sample_msi(start="2020-01-01", periods=8):
+    """Generate simulated quarterly MSI data."""
+    rng = pd.date_range(start=start, periods=periods, freq="Q")
+    trend = np.linspace(100, 120, periods)
+    noise = np.random.randn(periods) * 2
+    return pd.DataFrame({"date": rng, "msi": trend + noise})
+
+
+def interpolate_monthly(msi_quarterly: pd.DataFrame) -> pd.Series:
+    monthly = (
+        msi_quarterly.set_index("date")
+        .resample("M")
+        .interpolate("linear")
+    )
+    return monthly["msi"]
+
+
+def sarimax_forecast(msi_monthly: pd.Series, steps: int = 12):
+    model = SARIMAX(msi_monthly, order=(1, 1, 1), seasonal_order=(1, 1, 1, 12))
+    res = model.fit(disp=False)
+    pred = res.get_forecast(steps=steps)
+    return pred.predicted_mean, pred.conf_int(), res
+
+
+def simulate_pmi(dates: pd.DatetimeIndex) -> pd.Series:
+    np.random.seed(0)
+    pmi = 50 + np.sin(np.arange(len(dates)) / 6) * 5 + np.random.randn(len(dates))
+    return pd.Series(pmi, index=dates, name="PMI")
+
+
+def regression_predict(msi: pd.Series, pmi: pd.Series, future_pmi: pd.Series):
+    df = pd.DataFrame({"msi": msi, "pmi": pmi}).dropna()
+    X = df[["pmi"]]
+    y = df["msi"]
+    model = LinearRegression().fit(X, y)
+    preds = model.predict(future_pmi.to_frame())
+    rmse = mean_squared_error(y, model.predict(X), squared=False)
+    return preds, model.coef_[0], model.intercept_, rmse
+
+
+def plot_results(msi, forecast, ci, pmi, reg_pred):
+    fig, ax = plt.subplots(figsize=(10, 6))
+    msi.plot(ax=ax, label="Actual MSI")
+    forecast.plot(ax=ax, label="SARIMAX Forecast")
+    ax.fill_between(
+        ci.index, ci["lower msi"], ci["upper msi"], color="lightblue", alpha=0.3
+    )
+    reg_pred.plot(ax=ax, label="PMI Regression", linestyle="--")
+    ax.set_ylabel("MSI")
+    ax.legend()
+    ax2 = ax.twinx()
+    pmi.plot(ax=ax2, color="gray", alpha=0.4, label="PMI")
+    ax2.set_ylabel("PMI")
+    ax2.legend(loc="upper left")
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    msi_q = generate_sample_msi()
+    msi_m = interpolate_monthly(msi_q)
+    forecast, ci, _ = sarimax_forecast(msi_m)
+    all_dates = msi_m.index.append(ci.index)
+    pmi = simulate_pmi(all_dates)
+    reg_pred, slope, intercept, rmse = regression_predict(
+        msi_m, pmi.loc[msi_m.index], pmi.loc[ci.index]
+    )
+    reg_pred = pd.Series(reg_pred, index=ci.index, name="PMI Regression")
+
+    print(f"Regression slope: {slope:.3f} intercept: {intercept:.3f} RMSE: {rmse:.3f}")
+    plot_results(pd.concat([msi_m, forecast]), forecast, ci, pmi, reg_pred)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ yfinance
 feedparser
 beautifulsoup4
 requests
+statsmodels
+matplotlib

--- a/utils.py
+++ b/utils.py
@@ -19,8 +19,6 @@ try:
 except Exception:
     nlp = None
 
-KEYWORDS = ["AI", "M&A", "earnings", "guidance"]
-
 
 def load_json(file) -> List[dict]:
     """Load JSON content from uploaded file."""
@@ -114,11 +112,6 @@ def analyze_sentiment(text: str) -> float:
     return TextBlob(text).sentiment.polarity
 
 
-def keyword_frequency(text: str, keywords=KEYWORDS) -> Dict[str, int]:
-    text_lower = text.lower()
-    return {k: text_lower.count(k.lower()) for k in keywords}
-
-
 def extract_entities(text: str) -> List[str]:
     if not nlp:
         return []
@@ -153,7 +146,6 @@ def analyze_text_df(df: pd.DataFrame, text_col: str = "text") -> pd.DataFrame:
                 raise KeyError(text_col)
 
     df["sentiment"] = df[text_col].astype(str).apply(analyze_sentiment)
-    df["keywords"] = df[text_col].astype(str).apply(keyword_frequency)
     df["entities"] = df[text_col].astype(str).apply(extract_entities)
     # Normalize potential date column names
     date_col = None


### PR DESCRIPTION
## Summary
- remove keyword frequency feature from text analysis
- cleanup filing keyword cloud section of the app
- add a demo `msi_forecast.py` for MSI and PMI trend modelling
- update dependencies for statsmodels and matplotlib
- document MSI forecasting script in README

## Testing
- `python -m py_compile $(git ls-files '*.py') msi_forecast.py`

------
https://chatgpt.com/codex/tasks/task_e_686a926f89408329917d4070dfca71e6