### PR TITLE
Fix feature name mismatch in regression

### DIFF
--- a/msi_forecast.py
+++ b/msi_forecast.py
@@ -41,7 +41,9 @@ def regression_predict(msi: pd.Series, pmi: pd.Series, future_pmi: pd.Series):
     X = df[["pmi"]]
     y = df["msi"]
     model = LinearRegression().fit(X, y)
-    preds = model.predict(future_pmi.to_frame(name="pmi"))
+    future_df = future_pmi.to_frame()
+    future_df.columns = ["pmi"]
+    preds = model.predict(future_df)
     rmse = mean_squared_error(y, model.predict(X)) ** 0.5
     return preds, model.coef_[0], model.intercept_, rmse
 


### PR DESCRIPTION
## Summary
- handle case mismatched feature names when predicting in regression

## Testing
- `python - <<'PY'
from msi_forecast import generate_sample_msi, interpolate_monthly, sarimax_forecast, simulate_pmi, regression_predict
msi_q = generate_sample_msi()
msi_m = interpolate_monthly(msi_q)
forecast, ci, _ = sarimax_forecast(msi_m)
future_idx = ci.index
all_dates = msi_m.index.append(future_idx)
pmi = simulate_pmi(all_dates)
reg_pred, slope, intercept, rmse = regression_predict(msi_m, pmi.loc[msi_m.index], pmi.loc[future_idx])
print('Predictions shape:', reg_pred.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686a98836bf08329b4edb6eeb4ac7db5