### PR TITLE
Update MSI forecasting logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,7 +205,13 @@ lines = (
     .encode(x="date:T", y="msi:Q", color="type:N")
 )
 
-st.altair_chart(band + lines, use_container_width=True)
+vline = (
+    alt.Chart(pd.DataFrame({"date": [msi_m.index[-1]]}))
+    .mark_rule(color="gray", strokeDash=[4, 2])
+    .encode(x="date:T")
+)
+
+st.altair_chart(band + lines + vline, use_container_width=True)
 st.caption(
     f"Regression slope: {slope:.3f} intercept: {intercept:.3f} RMSE: {rmse:.3f}"
 )


### PR DESCRIPTION
## Summary
- simulate MSI data for 2024-2025 quarters
- adjust interpolation to use month start
- tweak SARIMAX configuration and PMI simulation
- highlight forecast start in Streamlit chart

## Testing
- `python -m py_compile msi_forecast.py app.py utils.py scrape_data.py`
- `python msi_forecast.py`

------
https://chatgpt.com/codex/tasks/task_e_686a9ab0f7788329bbd0b5bb6beec027