### PR TITLE
Fix feature name mismatch in regression

### DIFF
--- a/msi_forecast.py
+++ b/msi_forecast.py
@@ -57,13 +57,20 @@ def simulate_pmi(dates: pd.DatetimeIndex) -> pd.Series:
 
 
 def regression_predict(msi: pd.Series, pmi: pd.Series, future_pmi: pd.Series):
+    """Predict future MSI values based on PMI."""
+    pmi = pmi.rename("pmi")
+    future_pmi = future_pmi.rename("pmi")
+
     df = pd.DataFrame({"msi": msi, "pmi": pmi}).dropna()
     X = df[["pmi"]]
     y = df["msi"]
+
     model = LinearRegression().fit(X, y)
+
     future_df = future_pmi.to_frame()
     future_df.columns = ["pmi"]
     preds = model.predict(future_df)
+
     rmse = mean_squared_error(y, model.predict(X)) ** 0.5
     return preds, model.coef_[0], model.intercept_, rmse
 


### PR DESCRIPTION
## Summary
- rename PMI series to ensure consistent feature names

## Testing
- `python - <<'PY'
import msi_forecast as mf
msi_q = mf.generate_sample_msi()
msi_m = mf.interpolate_monthly(msi_q)
forecast, ci, _ = mf.sarimax_forecast(msi_m)
future_idx = ci.index
all_dates = msi_m.index.append(future_idx)
pmi = mf.simulate_pmi(all_dates).rename('PMI')
preds = mf.regression_predict(msi_m, pmi.loc[msi_m.index], pmi.loc[future_idx])
print('predicted', len(preds[0]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_686a9e9688648329ba502ac8c0c25688